### PR TITLE
Fix broken 7GUI link formatting in readme

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Robin Heggelund Hansen
 Gaute Berge
 Oliver Schöning
+Nils Henrik Hals

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Traditionally the first program one creates in any language, here implemented as
 
 ## 7GUIs
 
-7GUIs is a set of small tasks, suitable for demonstrating how common GUI patterns can be implemented in a specific framework. The following folders implement the solutions to the [https://eugenkiss.github.io/7guis/tasks](7GUIs) tasks:
+[7GUIs](https://eugenkiss.github.io/7guis) is a set of small tasks, suitable for demonstrating how common GUI patterns can be implemented in a specific framework. The following folders implement the solutions to the [7GUIs tasks](https://eugenkiss.github.io/7guis/tasks):
 
 * counter
 * __todo__


### PR DESCRIPTION
Fixes a broken link that was linking to the wrong target, and adds a link to 7GUIs index at first mention.